### PR TITLE
Update ACP.lua

### DIFF
--- a/ACP.lua
+++ b/ACP.lua
@@ -1502,8 +1502,8 @@ function ACP:SortDropDown_OnClick(sorter)
 end
 
 function ACP:DisableAllAddons()
-    DisableAllAddOns(UnitName("player"))
-    EnableAddOn(ACP_ADDON_NAME, UnitName("player"))
+    C_AddOns.DisableAllAddOns(UnitName("player"))
+    C_AddOns.EnableAddOn(ACP_ADDON_NAME, UnitName("player"))
 
     for k in pairs(savedVar.ProtectedAddons) do
         EnableAddOn(k, UnitName("player"))

--- a/ACP.xml
+++ b/ACP.xml
@@ -277,7 +277,7 @@
                 </Anchors>
                 <Scripts>
                     <OnClick>
-                        EnableAllAddOns()
+                        C_AddOns.EnableAllAddOns()
                         ACP:AddonList_OnShow(self)
                     </OnClick>
                 </Scripts>


### PR DESCRIPTION
Fixes

```
1x ACP/ACP.lua:1505: attempt to call global 'DisableAllAddOns' (a nil value)
[string "@ACP/ACP.lua"]:1505: in function `DisableAllAddons'
[string "@ACP/ACP.lua"]:1518: in function `DisableAll_OnClick'
[string "@ACP/ACP.lua"]:1355: in function `ClearSelectionAndLoadSet'
[string "@ACP/ACP.lua"]:1903: in function `func'
[string "@Blizzard_SharedXML/Mainline/UIDropDownMenu.lua"]:1034: in function `UIDropDownMenuButton_OnClick'
[string "*UIDropDownMenuTemplates.xml:93_OnClick"]:1: in function <[string "*UIDropDownMenuTemplates.xml:93_OnClick"]:1>

Locals:
self = <table> {
 dropDownFrame = ACP_SetDropDown {
 }
 embedded_libs_owners = <table> {
 }
 addonListBuilders = <table> {
 }
 ACP_BLIZZARD_ADDONS = <table> {
 }
 masterAddonList = <table> {
 }
 initSortDropDown = true
 sortedAddonList = <table> {
 }
 embedded_libs = <table> {
 }
 TAGS = <table> {
 }
 L = <table> {
 }
 CheckEvents = 0
 frame = ACP_AddonList {
 }
}
(*temporary) = nil
(*temporary) = "Caonizumu"
(*temporary) = nil
(*temporary) = "attempt to call global 'DisableAllAddOns' (a nil value)"
ACP_ADDON_NAME = "ACP"
savedVar = <table> {
 sorter = "Group By Name"
 NoRecurse = false
 NoChildren = true
 scale = 0.640000
 AddonSet = <table> {
 }
 collapsed = <table> {
 }
 ProtectedAddons = <table> {
 }
}
ACP_FRAME_NAME = "ACP_AddonList"
```